### PR TITLE
/usersのAPIを実装

### DIFF
--- a/backend/crud/user.py
+++ b/backend/crud/user.py
@@ -18,3 +18,6 @@ def create_user(db: Session, user: UserCreate) -> User:
     db.commit()
     db.refresh(db_user)
     return db_user
+
+def get_all_users(db: Session) -> list[User]:
+    return db.query(User).all()

--- a/backend/routers/api.py
+++ b/backend/routers/api.py
@@ -29,4 +29,3 @@ def get_user(user_id: int, db: Session = Depends(get_db)):
 def get_users(db: Session = Depends(get_db)):
     users = crud_user.get_all_users(db)
     return UsersResponse(users=users)
-    return UserResponse(user=user, account=account)

--- a/backend/routers/api.py
+++ b/backend/routers/api.py
@@ -26,6 +26,7 @@ def get_user(user_id: int, db: Session = Depends(get_db)):
     return UserResponse(user=user, account=account)
 
 @router.get("/users", response_model=UsersResponse)
-def get_users(db: Session = Depends(get_db)):
+def get_users(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     users = crud_user.get_all_users(db)
+    users.remove(current_user)
     return UsersResponse(users=users)

--- a/backend/routers/api.py
+++ b/backend/routers/api.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from database import SessionLocal
-from schemas.api import MeResponse
+from schemas.api import MeResponse, UsersResponse
 from crud import user as crud_user
 from crud import account as crud_account
 
@@ -22,3 +22,8 @@ def get_me(db: Session = Depends(get_db)):
     user = crud_user.get_user_by_id(db, user_id)
     account = crud_account.get_account_by_user_id(db, user_id)
     return MeResponse(user=user, account=account)
+
+@router.get("/users", response_model=UsersResponse)
+def get_users(db: Session = Depends(get_db)):
+    users = crud_user.get_all_users(db)
+    return UsersResponse(users=users)

--- a/backend/schemas/api.py
+++ b/backend/schemas/api.py
@@ -6,3 +6,6 @@ from schemas.account import AccountPublic
 class MeResponse(BaseModel):
     user: UserPublic
     account: AccountPublic
+
+class UsersResponse(BaseModel):
+    users: list[UserPublic]


### PR DESCRIPTION
## 内容
- 関数``get_all_users``をCRUDに追加
- usersの処理を追加


## テスト
- メインとの競合を解消したのち、``/users/<user-id>``と``/users``の稼働を確認。